### PR TITLE
Add omitWhen effects on validation messages and change sidebar positions

### DIFF
--- a/docs/writing_your_suite/including_and_excluding/omitWhen.md
+++ b/docs/writing_your_suite/including_and_excluding/omitWhen.md
@@ -1,16 +1,18 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 # omitWhen - Conditionally omit tests from a suite
 
-In some cases, we need to wish to omit certain portions of our suite in a way that these tests won't run, and will not count agains `isValid`. For example, when we have some tests that are only allowed to run when a certain checkbox is checked by the user.
+In some cases, we need to wish to omit certain portions of our suite in a way that these tests won't run, and will not count against `isValid`. For example, when we have some tests that are only allowed to run when a certain checkbox is checked by the user.
 
 Generally, when we skip fields, they are counted against `isValid`, meaning, unless specifically marked as `optional`, the suite will not be regarded as valid. Using `omitWhen` fixes it by both preventing the omitted tests from running, _and_ allowing the suite to be valid even without them.
 
 ## Differences from `skipWhen`
 
 When using `skipWhen` the tests within the block will be skipped, but will still be counted against `isValid`. When using `omitWhen`, the tests within the block will be omitted, and will not be counted against `isValid`.
+
+This also means that the validation message of a test, enclosed by `omitWhen`, is omitted from the suite result if the condition for the `omitWhen` is true. It is unlike the `skipWhen` modifier which caches the validation message of an enclosed test whether the test is skipped or not.
 
 ## Params
 

--- a/docs/writing_your_suite/including_and_excluding/omitWhen.md
+++ b/docs/writing_your_suite/including_and_excluding/omitWhen.md
@@ -12,7 +12,7 @@ Generally, when we skip fields, they are counted against `isValid`, meaning, unl
 
 When using `skipWhen` the tests within the block will be skipped, but will still be counted against `isValid`. When using `omitWhen`, the tests within the block will be omitted, and will not be counted against `isValid`.
 
-This also means that the validation message of a test, enclosed by `omitWhen`, is omitted from the suite result if the condition for the `omitWhen` is true. It is unlike the `skipWhen` modifier which caches the validation message of an enclosed test whether the test is skipped or not.
+This also means that the validation message of a test, enclosed by `omitWhen`, is omitted from the suite result if the condition for the `omitWhen` is true. It is unlike the `skipWhen` modifier which caches the validation message of an enclosed test if the test was skipped.
 
 ## Params
 

--- a/docs/writing_your_suite/including_and_excluding/omitWhen.md
+++ b/docs/writing_your_suite/including_and_excluding/omitWhen.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # omitWhen - Conditionally omit tests from a suite

--- a/docs/writing_your_suite/including_and_excluding/skipWhen.md
+++ b/docs/writing_your_suite/including_and_excluding/skipWhen.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # skipWhen: Conditional Exclusion

--- a/docs/writing_your_suite/including_and_excluding/skip_and_only_group.md
+++ b/docs/writing_your_suite/including_and_excluding/skip_and_only_group.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Including and excluding groups


### PR DESCRIPTION
I thought it might be better to explicitly write about the effects on validation messages. It might not be immediately apparent for people.

The change to the sidebar positions is just a proposal. But before it, the positions were quite mixed up. Now the skipWhen and omitWhen are next to each other as well as the skip/only docs.